### PR TITLE
Recursively search for tests

### DIFF
--- a/src/mguttestsuite__define.pro
+++ b/src/mguttestsuite__define.pro
@@ -278,7 +278,7 @@ pro mguttestsuite::add, tests, all=all, _extra=e
                            count=nTestDirs)
     for d = 0L, nTestDirs - 1L do begin
       ; if there is a *_uts__define.pro here then add it
-      uts = file_search(testDirs[d] + '*_uts__define.pro', $
+      uts = file_search(testDirs[d], '*_uts__define.pro', $
                         count=nTestSuites)
       if (nTestSuites gt 0) then begin
         suiteName = file_basename(uts[0])
@@ -291,7 +291,7 @@ pro mguttestsuite::add, tests, all=all, _extra=e
 
       ; if there isn't a *_uts__define.pro, but there are unit tests here
       ; then create a new test suite
-      uts = file_search(testDirs[d] + '*_ut__define.pro', $
+      uts = file_search(testDirs[d], '*_ut__define.pro', $
                         count=nTestCases)
       if (nTestCases eq 0) then continue   ; finished with this directory
 


### PR DESCRIPTION
This change implements recursive searching for test below the test suite top leve home directory.

My directory structure looks something like

.../alg1/test/src/
.../alg2/test/src/
.../alg3/test/src/
.../test/src/

where each algorithm has its own unit tests and I'd like to keep the test suite covering all the individual test in the last directory. As I understand it, I can set the HOME keyword to '../../' to change the root of the test suite, but that will only result in searching the alg* directories one level down. I believe my changes here would allow for recursive searching.