### PR TITLE
Recursively add super classes.

### DIFF
--- a/src/mguttestcase__define.pro
+++ b/src/mguttestcase__define.pro
@@ -494,7 +494,16 @@ pro mguttestcase::findTestnames
                                           ntests=ntests, $
                                           have_output=have_output)
 
-  superclassnames = obj_class(self, count=nsuperclasses, /superclass)
+  superclassnames = list(obj_class(self, count=nsuperclasses, /superclass), /extract)
+  
+  foreach class, superclassnames do begin
+    super = obj_class(class, count=nsuper, /superclass)
+    if (nsuper gt 0) then begin
+      superclassnames.Add, super, /extract
+      nsuperclasses += nsuper
+    endif
+  endforeach
+  
   for s = 0L, nsuperclasses - 1L do begin
     tnames = self->findTestnamesForClass(superclassnames[s], $
                                          ntests=nsupertests, $


### PR DESCRIPTION
Add superclasses recursively. Accounts for case where a superclass of a test case class is itself a subclass. Previously only the immediate parent class was added to the test method search, so tests in the 'grandparent class' were not found.